### PR TITLE
TCal and TCal Manager

### DIFF
--- a/include/TCal.h
+++ b/include/TCal.h
@@ -26,7 +26,6 @@
 
 #include "../include/TGRSITransition.h"
 
-
 class TCal : public TNamed {
  public: 
    TCal();
@@ -39,22 +38,20 @@ class TCal : public TNamed {
    virtual Double_t GetParameter(Int_t parameter) const = 0;
 
  public:
-   UInt_t GetChannelNumber() const { return fchanNum; }
    TGraphErrors *Graph() const { return fgraph; }
-   virtual void WriteToChannel() const { printf("Not defined for %s\n",ClassName()); }
+   virtual void WriteToChannel() const {Error("WriteToChannel","Not defined for %s",ClassName());}
 
+   TChannel *GetChannel() const;
+   Bool_t SetChannel(const TChannel* chan);
+   Bool_t SetChannel(UInt_t channum);
    virtual void SetFitFunction(void* fnc){};
    virtual void Print(Option_t *opt = "") const;
    virtual void Clear(Option_t *opt = "");
 
- protected: 
-   
-   void SetChannelNumber(UInt_t channum) { fchanNum = channum; }
-
  private:
    void InitTCal();
-   UInt_t fchanNum;
    TGraphErrors *fgraph;
+   TChannel *fchan;
 
    ClassDef(TCal,1);
 

--- a/include/TCalManager.h
+++ b/include/TCalManager.h
@@ -17,8 +17,9 @@ class TCalManager : public TNamed {
    void AddToManager(TCal* cal, Option_t *opt = "");
    void RemoveCal(UInt_t channum, Option_t *opt="");
    void SetClass(const char* classname);
-   void SetClass(TClass *cl);
-   const char* GetClass(){ return fClass ? fClass->ClassName() : 0;}
+   void SetClass(const TClass *cl);
+   const char* GetClass(){ return fClass ? fClass->GetName() : 0;}
+   void WriteToChannel() const;
 
    virtual void Print(Option_t *opt = "") const;
    virtual void Clear(Option_t *opt = "");

--- a/include/TGainMatch.h
+++ b/include/TGainMatch.h
@@ -27,7 +27,7 @@ class TGainMatch : public TCal {
    void Print(Option_t *opt = "") const;
 
    Bool_t IsGroupable() const {return false;}
-   void WriteToTChannel() const;
+   void WriteToChannel() const;
 
  private:
    Bool_t fcoarse_match;

--- a/include/TGainMatch.h
+++ b/include/TGainMatch.h
@@ -27,7 +27,7 @@ class TGainMatch : public TCal {
    void Print(Option_t *opt = "") const;
 
    Bool_t IsGroupable() const {return false;}
-   void WriteToChannel() const { printf("Not defined for this cal\n"); }
+   void WriteToTChannel() const;
 
  private:
    Bool_t fcoarse_match;

--- a/libraries/TGRSIAnalysis/TCal/TCal.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TCal.cxx
@@ -19,16 +19,44 @@ TCal::~TCal(){
    fgraph = 0;
 }
 
+Bool_t TCal::SetChannel(const TChannel* chan){
+   if(!chan){
+      Error("SetChannel","TChannel does not exist");
+      return false;
+   }
+
+   fchan = (TChannel*)chan;
+   return true;
+}
+
+Bool_t TCal::SetChannel(UInt_t channum){
+   TChannel *chan = TChannel::GetChannelByNumber(channum);
+   if(!chan){
+      Error("SetChannel","Channel Number %d does not exist in current memory.",channum);
+      return false;
+   }
+   else
+      return SetChannel(chan);
+}
+
+TChannel* TCal::GetChannel() const {
+   return fchan;
+}
+
 void TCal::Clear(Option_t *opt) {
-   this->fchanNum = 9999;
+   fchan = 0;
    fgraph->Clear();
 }
 
 void TCal::Print(Option_t *opt) const{
-   printf("Channel Number: %u\n",fchanNum);
+   if(fchan)
+      printf("Channel Number: %u\n",fchan->GetNumber());
+   else
+      printf("Channel Number: NOT SET\n");
 }
 
 void TCal::InitTCal() {
    fgraph = new TGraphErrors;
+   fchan = 0;
    Clear();
 }

--- a/libraries/TGRSIAnalysis/TCal/TGainMatch.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TGainMatch.cxx
@@ -181,6 +181,11 @@ Bool_t TGainMatch::FineMatch(TH1* hist1, Double_t energy1, TH1* hist2, Double_t 
 
 std::vector<Double_t> TGainMatch::GetParameters() const{
    std::vector<Double_t> paramlist;
+   if(!(this->Graph()->GetFunction("gain"))){
+      Error("GetParameters","Gains have not been fitted yet");
+      return paramlist;
+   }
+   
    Int_t nparams = this->Graph()->GetFunction("gain")->GetNpar();
 
    for(int i=0;i<nparams;i++)
@@ -190,11 +195,22 @@ std::vector<Double_t> TGainMatch::GetParameters() const{
 }
 
 Double_t TGainMatch::GetParameter(Int_t parameter) const{
+   if(!(this->Graph()->GetFunction("gain"))){
+      Error("GetParameter","Gains have not been fitted yet");
+      return 0;
+   }
    return Graph()->GetFunction("gain")->GetParameter(parameter); //Root does all of the checking for us.
 }
 
-void TGainMatch::WriteToTChannel() const {
-
+void TGainMatch::WriteToChannel() const {
+   if(!GetChannel()){
+      Error("WriteToChannel","No Channel Set");
+      return;
+   }
+   GetChannel()->DestroyENGCal();
+   //Set the energy parameters based on the fitted gains.
+   GetChannel()->AddENGCoefficient(this->GetParameter(0));
+   GetChannel()->AddENGCoefficient(this->GetParameter(1));
 }
 
 void TGainMatch::Print(Option_t *opt) const {


### PR DESCRIPTION
- TCal and TCalManager are in a state I am happy with. 
- TCalManager only allows you to put one type of derived TCal in at any given time.
- Each TCal has a `TCal::WriteToChannel()` function that must be created, and defines what part of the TChannel is changed (energy coefs, etc.)
- The `TCalManager::WriteToChannel()` function iterates through every TCal in the manager and calls it's respective `WriteToChannel()` function.
- After calling a `Class::WriteToChannel()` function one must still call the `static TChannel::WriteCalFile("calfile.cal")`  