### PR TITLE
Reduced number of locks in TFragmentQueue::GetQueue

### DIFF
--- a/libraries/TGRSIFormat/TFragmentQueue.cxx
+++ b/libraries/TGRSIFormat/TFragmentQueue.cxx
@@ -22,14 +22,15 @@ std::map<int,int> TFragmentQueue::fragment_id_map;
 
 TFragmentQueue *TFragmentQueue::GetQueue(std::string quename)	{
 //Get a pointer to the global event Q with the name quename. 
-	while(TFragmentQueue::All.try_lock())	{
+   
+   if(fFragmentMap->count(quename) == 0) {
+	while(!TFragmentQueue::All.try_lock())	{
 		//try to lock Q, if another thread is using it do nothing
 	}
-   
-   if(fFragmentMap->count(quename) == 0)
       fFragmentMap->insert(std::pair<std::string,TFragmentQueue*>(quename,new TFragmentQueue));
    
    TFragmentQueue::All.unlock();
+}
 	//unlock the Q when this thread is done with it.
 	return fFragmentMap->at(quename);
 


### PR DESCRIPTION
I've moved the locking and unlocking of all fragment queues inside the if-statement. We do not need to lock the fragment queues to check if the one we request exists. We might not need any locking at all, since for the only operations we're using on the fragment map right now (count, insert, and at), accessing and modifying existing elements is safe. 
But this way we're only locking the fragment queues once (when our one and only fragment queue is created), and not every single time we get it.