### PR TITLE
Fixed bug where a copy of TChannel would be made

### DIFF
--- a/include/TCal.h
+++ b/include/TCal.h
@@ -40,18 +40,21 @@ class TCal : public TNamed {
  public:
    TGraphErrors *Graph() const { return fgraph; }
    virtual void WriteToChannel() const {Error("WriteToChannel","Not defined for %s",ClassName());}
+   virtual TF1* GetFitFunction() const { return ffitfunc; } 
+   virtual void SetFitFunction(const TF1* func){ ffitfunc = (TF1*)func; };
 
-   TChannel *GetChannel() const;
+   TChannel* const GetChannel() const;
    Bool_t SetChannel(const TChannel* chan);
    Bool_t SetChannel(UInt_t channum);
-   virtual void SetFitFunction(void* fnc){};
    virtual void Print(Option_t *opt = "") const;
    virtual void Clear(Option_t *opt = "");
 
  private:
    void InitTCal();
-   TGraphErrors *fgraph;
-   TChannel *fchan;
+   TGraphErrors *fgraph; //->
+   //This exclamation mark below makes it so TCalManager does not make a copy of the TChannel
+   TChannel *fchan;  //! 
+   TF1* ffitfunc; //->
 
    ClassDef(TCal,1);
 

--- a/include/TCalManager.h
+++ b/include/TCalManager.h
@@ -13,8 +13,8 @@ class TCalManager : public TNamed {
 
  public:
    TCal* GetCal(UInt_t channum);
-   void AddToManager(TCal* cal, UInt_t channum, Option_t *opt = ""); 
-   void AddToManager(TCal* cal, Option_t *opt = "");
+   Bool_t AddToManager(TCal* cal, UInt_t channum, Option_t *opt = ""); 
+   Bool_t AddToManager(TCal* cal, Option_t *opt = "");
    void RemoveCal(UInt_t channum, Option_t *opt="");
    void SetClass(const char* classname);
    void SetClass(const TClass *cl);

--- a/include/TGainMatch.h
+++ b/include/TGainMatch.h
@@ -2,10 +2,13 @@
 #define __TGAINMATCH_H__
 
 #include "TCal.h"
+#include "TCalManager.h"
 #include "TPeak.h"
 #include "TSpectrum.h"
+#include "TH2.h"
 #include <algorithm>
 #include <map>
+
 
 class TGainMatch : public TCal {
  public: 
@@ -14,6 +17,8 @@ class TGainMatch : public TCal {
    ~TGainMatch(){} 
 
  public:
+   static Bool_t CoarseMatchAll(TCalManager* cm,TH2 *mat, Double_t energy1 = 1173.228, Double_t energy2 = 1332.492);
+
    Bool_t CoarseMatch(TH1 *hist,Int_t channelNum,Double_t energy1 = 1173.228, Double_t energy2 = 1332.492);
    Bool_t FineMatch(TH1 *hist1, TPeak* peak1, TH1 *hist2, TPeak* peak2, Int_t channelNum);
    Bool_t FineMatch(TH1 *hist, TPeak* peak1, TPeak* peak2, Int_t channelNum);

--- a/libraries/TGRSIAnalysis/TCal/TCal.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TCal.cxx
@@ -24,7 +24,6 @@ Bool_t TCal::SetChannel(const TChannel* chan){
       Error("SetChannel","TChannel does not exist");
       return false;
    }
-
    fchan = (TChannel*)chan;
    return true;
 }
@@ -39,7 +38,7 @@ Bool_t TCal::SetChannel(UInt_t channum){
       return SetChannel(chan);
 }
 
-TChannel* TCal::GetChannel() const {
+TChannel* const TCal::GetChannel() const {
    return fchan;
 }
 
@@ -57,6 +56,7 @@ void TCal::Print(Option_t *opt) const{
 
 void TCal::InitTCal() {
    fgraph = new TGraphErrors;
+   ffitfunc = 0;
    fchan = 0;
    Clear();
 }

--- a/libraries/TGRSILoop/TGRSILoop.cxx
+++ b/libraries/TGRSILoop/TGRSILoop.cxx
@@ -136,6 +136,8 @@ void TGRSILoop::ProcessMidasFile(TMidasFile *midasfile) {
       return;
 
    fOffline = true;
+   //Once this is done, we want to set the frags read from midas to 0 for use in the next sort.
+   fFragsReadFromMidas = 0;
 
    std::ifstream in(midasfile->GetFilename(), std::ifstream::in | std::ifstream::binary);
    in.seekg(0, std::ifstream::end);
@@ -443,8 +445,6 @@ void TGRSILoop::Finalize() {
    printf(DMAGENTA "successfully sorted " DBLUE "%0d" DMAGENTA "/" 
           DCYAN "%0d" DMAGENTA "  ---> " DYELLOW " %.2f" DMAGENTA " percent passed." 
           RESET_COLOR "\n",fFragsSentToTree,fFragsReadFromMidas,((double)fFragsSentToTree/(double)fFragsReadFromMidas)*100.);
-   //Once this is done, we want to set the frags read from midas to 0 for use in the next sort.
-   fFragsReadFromMidas = 0;
 
 //   TIter *iter = TChannel::GetChannelIter();   
 //   while(TChannel *chan = (TChannel*)iter->Next()) {

--- a/users/UserInitObj.h
+++ b/users/UserInitObj.h
@@ -47,7 +47,7 @@
    GetOutputList()->Add(new TH1D("MidasTimeStamp","MidasTimeStamp",1000000,0,1000000));	
    GetOutputList()->Add(new TH1D("TriggerId","TriggerId",1000000,6000000,10000000));
 
-   GetOutputList()->Add(new TH2D("hp_charge","Channel vs Charge",64,0,64,12000,0,12000));
+   GetOutputList()->Add(new TH2D("hp_charge","Channel vs Charge",64,0,64,24000,0,12000));
    GetOutputList()->Add(new TH2D("hp_energy","Channel vs Energy",64,0,64,10000,0,2500));
    
    GetOutputList()->Add(new TH1D("test","test",128,-64,64));


### PR DESCRIPTION
I have learned that if you have a pointer as a member of a class, that if you Write or Clone an object of the class, ROOT's Streamer facility makes a copy of the object referenced by that pointer, and then sets the new pointer to point to that new memory. I have gotten around this in this specific case by adding a //! after the Channel pointer in TCalManager. The streamer facility then makes a clone of the TCal, but leaves the TChannel pointer pointing at NULL. I then set the pointer to point at the TChannel of the old TCal. @pcbend, I am sure I am just rediscovering what you have already found with the write speed/memory size when we were writing the analysis tree. However, when I was looking into this stuff I found a Class called TRef that might solve my problem as it creates a persistent reference to a TObject with respect to streamers. I'm going to try to "fix this bug" using TRef's instead of the above mentioned way and see if I can understand how they work a little better.