### PR TITLE
OS X Compatibility changes for UTMPX and X11, also minor makefile change.

### DIFF
--- a/src/main.cxx
+++ b/src/main.cxx
@@ -7,6 +7,17 @@
 #include "TEnv.h"
 #include "TGRSIint.h"
 
+#ifdef __APPLE__
+#define HAVE_UTMPX_H
+#define UTMP_NO_ADDR
+#ifndef ut_user
+#   define ut_user ut_name
+#endif
+#ifndef UTMP_FILE
+#define UTMP_FILE "/etc/utmp"
+#endif
+#endif
+
 
 # ifdef HAVE_UTMPX_H
 # include <utmpx.h>

--- a/src/makefile
+++ b/src/makefile
@@ -16,6 +16,9 @@ INC = -I$(BASE)/include
 INC += -I$(MIDASSYS)/include
 
 LIBDIR = -L$(BASE)/libraries
+ifeq ($(PLATFORM),Darwin)
+LIBDIR += -L/opt/X11/lib 
+endif
 ifdef MIDASSYS
 ifeq ($(PLATFORM),Darwin)
 LIBDIR += -L$(MIDASSYS)/darwin/lib
@@ -69,7 +72,7 @@ SYSLIBS += -lXpm
 
 grsisort: $(OBJECTS) $(LIBRARIES)
 	@printf " ${COM_COLOR}%s ${OBJ_COLOR}\t grsisort ${NO_COLOR}" $(COMP_STRING)
-	@$(CXX) $^ $(CFLAGS) $(CPPFLAGS) $(INC) $(LIBDIR) $(LFALGS) $(LIBS) $(DETLIBS) $(LDROOT) $(SYSLIBS) -o $@  2> temp.log || touch temp.errors
+	@$(CXX) $^ $(CFLAGS) $(CPPFLAGS) $(INC) $(LIBDIR) $(LIBS) $(DETLIBS) $(LDROOT) $(SYSLIBS) -o $@  2> temp.log || touch temp.errors
 	@if test -e temp.errors; then  \
 	 printf "\r ${COM_COLOR}%s ${OBJ_COLOR}%-30s ${ERROR_COLOR}%*s${NO_COLOR}\n" $(COMP_STRING) $@ 10 $(ERROR_STRING) \
 	 && $(CAT) temp.log  \


### PR DESCRIPTION
Added OS X compatibility defines for UTMPX. (Needed for black and white splash screen).
Updated src makefile for X11 OS X compatibility.
Removed unused $(LFALGS) variable from grsisort compilation.