### PR TITLE
TFragmentQueue::GetQueue fixed

### DIFF
--- a/libraries/TGRSIFormat/TFragmentQueue.cxx
+++ b/libraries/TGRSIFormat/TFragmentQueue.cxx
@@ -24,16 +24,18 @@ TFragmentQueue *TFragmentQueue::GetQueue(std::string quename)	{
 //Get a pointer to the global event Q with the name quename. 
    
    if(fFragmentMap->count(quename) == 0) {
-	while(!TFragmentQueue::All.try_lock())	{
-		//try to lock Q, if another thread is using it do nothing
-	}
-      fFragmentMap->insert(std::pair<std::string,TFragmentQueue*>(quename,new TFragmentQueue));
+      while(!TFragmentQueue::All.try_lock())	{
+         //try to lock Q, if another thread is using it do nothing
+      }
+      if(fFragmentMap->count(quename) == 0) {
+	 fFragmentMap->insert(std::pair<std::string,TFragmentQueue*>(quename,new TFragmentQueue));
+      }
    
-   TFragmentQueue::All.unlock();
-}
-	//unlock the Q when this thread is done with it.
-	return fFragmentMap->at(quename);
+      //unlock the Q when this thread is done with it.
+      TFragmentQueue::All.unlock();
+   }
 
+   return fFragmentMap->at(quename);
 }
 
 TFragmentQueue::TFragmentQueue()	{	


### PR DESCRIPTION
 There was an error in the last change I did, by moving the lock between the calls to map::count and map::insert, it is possible that another thread inserts the same map again. To keep avoiding locking and un-locking too often, I've added another check that map::count returns zero after the locking.