### PR TITLE
Bugs in TPeak.

### DIFF
--- a/include/TCal.h
+++ b/include/TCal.h
@@ -1,6 +1,7 @@
 #ifndef __TCAL_H__
 #define __TCAL_H__
 
+#include "Varargs.h"
 #include "TNamed.h"
 #include "TH1.h"
 #include "TF1.h"
@@ -44,6 +45,8 @@ class TCal : public TNamed {
    virtual void SetFitFunction(const TF1* func){ ffitfunc = (TF1*)func; };
    virtual std::vector<Double_t> GetParameters() const;
    virtual Double_t GetParameter(Int_t parameter) const ;
+
+   //static TGraphErrors MergeGraphs(TCal *cal,...);
 
    TChannel* const GetChannel() const;
    Bool_t SetChannel(const TChannel* chan);

--- a/include/TChannel.h
+++ b/include/TChannel.h
@@ -159,7 +159,7 @@ class TChannel : public TNamed	{
     void DestroyTIMECal();
     void DestroyEFFCal();
 
-    static void ReadCalFromTree(TTree*,Option_t *opt="overwrite");
+    static Int_t ReadCalFromTree(TTree*,Option_t *opt="overwrite");
     static Int_t ReadCalFile(const char *filename = "");
     static void WriteCalFile(std::string outfilename = "");
 

--- a/include/TEfficiencyCal.h
+++ b/include/TEfficiencyCal.h
@@ -15,6 +15,8 @@ class TEfficiencyCal : public TCal {
 
  public:
    void Copy(TObject &obj) const;
+   void AddPoint(Double_t energy, Double_t area, Double_t d_energy=0.0, Double_t d_area=0.0);
+   void AddPoint(TPeak *peak);
 
    void Clear(Option_t *opt = "");
    void Print(Option_t *opt = "") const;

--- a/include/TPeak.h
+++ b/include/TPeak.h
@@ -38,7 +38,7 @@ class TPeak : public TGRSIFit {
    void SetCentroid(Double_t cent)  { SetParameter("centroid",cent); }
    void SetType(Option_t *type);
 
-   Bool_t Fit(TH1* fithist, Option_t *opt = "");
+   Bool_t Fit(TH1* fithist, Option_t *opt = ""); //Might switch this to TFitResultPtr
   // Bool_t Fit(TH1* fithist = 0);
 
    Double_t GetCentroid() const     { return GetParameter("centroid"); }

--- a/libraries/TGRSIAnalysis/TCal/TCal.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TCal.cxx
@@ -24,6 +24,30 @@ TCal::TCal(const TCal &copy) : TNamed(copy){
    ((TCal&)copy).Copy(*this);
 }
 
+/*TGraphErrors TCal::MergeGraphs(TCal *cal,...){
+   //Probably does not work properly yet
+   TGraphErrors ge;
+   TList* glist;
+   TClass *cl = cal->Class();
+   if(!(cal->IsGroupable())){
+      cal->Error("MergeGraphs","%s is not groupable",cal->ClassName());
+      return ge;
+   }
+   va_list ap;
+   va_start(ap, cal);
+   while(cal){
+      if(cal->Class() != cl){
+         cal->Error("MergeGraphs","Trying to merge a %s to a %s",cal->ClassName(),cl->ClassName());
+         return ge;
+      }
+      glist.Add(cal->Graph());
+      cal= var_arg(ap, TCal*);
+   }
+   va_end(ap);
+   ge.Merge(glist);
+   return ge;
+}*/
+
 void TCal::SetNucleus(TNucleus* nuc){
    if(!nuc){
       Error("SetNucleus","Nucleus does not exist");
@@ -31,6 +55,10 @@ void TCal::SetNucleus(TNucleus* nuc){
    }
    if(fnuc)
       Warning("SetNucleus","Overwriting nucleus: %s",fnuc->GetName());
+   if(!(nuc->SetSourceData())){
+      Error("SetNucleus","Source Data not found for %s",nuc->GetName());
+      return;
+   }
    fnuc = nuc;
 }
 

--- a/libraries/TGRSIAnalysis/TCal/TEfficiencyCal.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TEfficiencyCal.cxx
@@ -29,6 +29,36 @@ void TEfficiencyCal::ScaleGraph(Double_t scale_factor){
    fscale_factor = scale_factor;
 }
 
+void TEfficiencyCal::AddPoint(TPeak* peak){
+   if(!peak){
+      Error("AddPoint","Peak is empty");
+      return;
+   }
+   AddPoint(peak->GetCentroid(),peak->GetArea(),peak->GetCentroidErr(),peak->GetAreaErr());
+}
+
+void TEfficiencyCal::AddPoint(Double_t energy, Double_t area, Double_t d_energy, Double_t d_area){
+   if(!GetNucleus()){
+      Error("AddPoint", "No nucleus set");
+      return;
+   }
+//Will eventually write a method that doesn't need a nucleus
+
+   Double_t efficiency,d_efficiency;
+   Double_t intensity = 1.0;//nuc;
+   Double_t d_intensity = 0.1;
+
+   efficiency = area/intensity;
+   d_efficiency = efficiency*TMath::Sqrt(TMath::Power(d_efficiency/efficiency,2.0) + TMath::Power(d_area/area,2.0));
+
+   Graph()->SetPoint(Graph()->GetN(), energy, efficiency);
+   Graph()->SetPointError(Graph()->GetN()-1,d_energy,d_efficiency);
+
+   Graph()->Sort(); //This keeps the points in order of energy;
+
+}
+
+
 void TEfficiencyCal::Print(Option_t *opt) const {
    TCal::Print();
 }

--- a/libraries/TGRSIAnalysis/TCal/TGainMatch.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TGainMatch.cxx
@@ -146,14 +146,26 @@ Bool_t TGainMatch::FineMatch(TH1* hist1, TPeak* peak1, TH1* hist2, TPeak* peak2,
    Double_t energy[2] = {peak1->GetParameter("centroid"), peak2->GetParameter("centroid")};
    std::cout << peak1->GetParameter("centroid") << " ENERGIES " << energy[1] << std::endl;  
    //Offsets are very small right now so I'm not including them until they become a problem.
-   peak1->SetParameter("centroid",energy[0]/gain);
-   peak2->SetParameter("centroid",energy[1]/gain);
-
+  // peak1->SetParameter("centroid",energy[0]/gain);
+  // peak2->SetParameter("centroid",energy[1]/gain);
    //Change the range for the fit to be in the gain corrected spectrum
 
    peak1->SetRange(peak1->GetXmin()/gain,peak1->GetXmax()/gain);
    peak2->SetRange(peak2->GetXmin()/gain,peak2->GetXmax()/gain);
 
+   //The gains won't be perfect, so we need to search for the peak within a range.
+   TSpectrum s;
+   Int_t nfound = s.Search(hist1); 
+   for(int x=0;x<nfound;x++)
+      if(s.GetPositionX()[x] < peak1->GetXmax() && s.GetPositionX()[x] > peak1->GetXmin()) 
+        peak1->SetParameter("centroid",s.GetPositionX()[x]);
+
+   s.Clear();//Clear s, so that we can use it again.
+   nfound = s.Search(hist2); //Search the next histogram
+   for(int x=0;x<nfound;x++)
+      if(s.GetPositionX()[x] < peak2->GetXmax() && s.GetPositionX()[x] > peak2->GetXmin()) 
+         peak2->SetParameter("centroid",s.GetPositionX()[x]);
+   
    peak1->Fit(hist1,"M+");
    peak2->Fit(hist2,"M+");
    

--- a/libraries/TGRSIAnalysis/TCal/TGainMatch.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TGainMatch.cxx
@@ -72,7 +72,7 @@ Bool_t TGainMatch::CoarseMatch(TH1* hist, Int_t chanNum, Double_t energy1, Doubl
    Graph()->Set(2);
 
    //We now want to create a peak for each one we found (2) and fit them.
-   for(int x=0; x<nfound; x++){
+   for(int x=0; x<2; x++){
       TPeak tmpPeak(foundbin[x],foundbin[x] - 20./binWidth, foundbin[x] + 20./binWidth);
       tmpPeak.SetName(Form("GM_Cent_%lf",foundbin[x]));//Change the name of the TPeak to know it's origin
       tmpPeak.Fit(hist,"M+");

--- a/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
@@ -158,15 +158,17 @@ Bool_t TPeak::Fit(TH1* fithist,Option_t *opt){
 
 
 
-   TFitResultPtr fitres = fithist->Fit(this,Form("%sRSM",opt));//The RS needs to always be there
+   TFitResultPtr fitres = fithist->Fit(this,Form("%sRSML",opt));//The RS needs to always be there
 
    if(fitres->ParError(2) != fitres->ParError(2)){ //Check to see if nan
       if(fitres->Parameter(3) < 1){
          FixParameter(4,0);
          FixParameter(3,1);
          std::cout << "Beta may have broken the fit, retrying with R=0" << std::endl;
-         fitres = fithist->Fit(this,Form("%sRSM",opt));
+         fitres = fithist->Fit(this,Form("%sRSML",opt));
       }
+    
+
    }
 
    Double_t binWidth = fithist->GetBinWidth(GetParameter("centroid"));

--- a/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
@@ -169,11 +169,17 @@ Bool_t TPeak::Fit(TH1* fithist,Option_t *opt){
       }
    }
 
+   Double_t binWidth = fithist->GetBinWidth(GetParameter("centroid"));
    printf("Chi^2/NDF = %lf\n",fitres->Chi2()/fitres->Ndf());
    Double_t xlow,xhigh;
+   Double_t int_low, int_high; 
    this->GetRange(xlow,xhigh);
+   int_low = xlow - 200.*binWidth;
+   int_high = xhigh + 200.*binWidth;
+
    //Make a function that does not include the background
    TPeak *tmppeak = new TPeak(*this);
+   tmppeak->SetRange(int_low,int_high);//This will help get the true area of the gaussian 200 ~ infinity in a gaus
    tmppeak->SetName("tmppeak");
    tmppeak->SetParameter("step",0.0);
    tmppeak->SetParameter("A",0.0);
@@ -182,8 +188,8 @@ Bool_t TPeak::Fit(TH1* fithist,Option_t *opt){
    
    //This is where we will do integrals and stuff.
    if(farea < 0.01){
-      farea = tmppeak->Integral(xlow,xhigh);
-      fd_area = tmppeak->IntegralError(xlow,xhigh,tmppeak->GetParameters(),fitres->GetCovarianceMatrix().GetMatrixArray());
+      farea = tmppeak->Integral(int_low,int_high)/binWidth;
+      fd_area = tmppeak->IntegralError(int_low,int_high,tmppeak->GetParameters(),fitres->GetCovarianceMatrix().GetMatrixArray())/binWidth;
    }
    delete tmppeak;
    

--- a/libraries/TGRSIFormat/TChannel.cxx
+++ b/libraries/TGRSIFormat/TChannel.cxx
@@ -458,10 +458,10 @@ void TChannel::WriteCalFile(std::string outfilename) {
 }
 
 
-void TChannel::ReadCalFromTree(TTree *tree,Option_t *opt) {
+Int_t TChannel::ReadCalFromTree(TTree *tree,Option_t *opt) {
 //Reads the TChannel information from a Tree if it has already been written to that Tree.
     if(!tree)
-	return;
+	return 0;
     TList *list = tree->GetUserInfo();	
     TIter iter(list);
     int channelsfound = 0;
@@ -472,7 +472,7 @@ void TChannel::ReadCalFromTree(TTree *tree,Option_t *opt) {
  	AddChannel(chan,opt);// if we read from the tree we want to overwrite any channels found
 	channelsfound ++;
     }
-    return;
+    return channelsfound;
 }
 
 

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -77,11 +77,8 @@ void TGRSIint::ApplyOptions() {
    if(fAutoSort){
      TGRSILoop::Get()->SortMidas();
    }
-   
-   
    bool foundCal = false;
    if(fFragmentSort && TGRSIOptions::GetInputRoot().size()!=0)
-      //We should put a line here that reads a cal file so the hists are altered based on the input cal file
       TGRSIRootIO::Get()->MakeUserHistsFromFragmentTree();
    if(TGRSIOptions::MakeAnalysisTree() && TGRSIOptions::GetInputRoot().size()!=0) { 
       TAnalysisTreeBuilder::Get()->StartMakeAnalysisTree();

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -81,6 +81,7 @@ void TGRSIint::ApplyOptions() {
    
    bool foundCal = false;
    if(fFragmentSort && TGRSIOptions::GetInputRoot().size()!=0)
+      //We should put a line here that reads a cal file so the hists are altered based on the input cal file
       TGRSIRootIO::Get()->MakeUserHistsFromFragmentTree();
    if(TGRSIOptions::MakeAnalysisTree() && TGRSIOptions::GetInputRoot().size()!=0) { 
       TAnalysisTreeBuilder::Get()->StartMakeAnalysisTree();
@@ -95,12 +96,12 @@ void TGRSIint::ApplyOptions() {
    }
    if(TGRSIOptions::GetInputRoot().size() > 0) {
       if(TGRSIOptions::GetInputRoot().at(0).find("fragment") != std::string::npos){
-         ProcessLine("TChannel::ReadCalFromTree(FragmentTree)");
-         printf("Reading Calibration from from \"%s\" FragmentTree if it exists\n",TGRSIOptions::GetInputRoot().at(0).c_str()); //Will put real file name in here but it's bed time
+         Int_t chans_read = ProcessLine("TChannel::ReadCalFromTree(FragmentTree)");
+         printf("Read calibration info for %d channels from \"%s\" FragmentTree\n",chans_read,TGRSIOptions::GetInputRoot().at(0).c_str()); 
       }   
       if(TGRSIOptions::GetInputRoot().at(0).find("analysis") != std::string::npos){ 
-         ProcessLine("TChannel::ReadCalFromTree(AnalysisTree)");    
-         printf("Reading Calibration from from \"%s\" AnalysisTree if it exists\n",TGRSIOptions::GetInputRoot().at(0).c_str());
+         Int_t chans_read = ProcessLine("TChannel::ReadCalFromTree(AnalysisTree)");    
+         printf("Read calibration info for %d channels from \"%s\" AnalysisTree\n",chans_read,TGRSIOptions::GetInputRoot().at(0).c_str());
       }
    }
   

--- a/users/UserInitObj.h
+++ b/users/UserInitObj.h
@@ -33,7 +33,7 @@
    GetOutputList()->Add(new TH1D("Charge_0x100d","Charge_0x100d",8000,0,4000));
    GetOutputList()->Add(new TH1D("Charge_0x100e","Charge_0x100e",8000,0,4000));
    GetOutputList()->Add(new TH1D("Charge_0x100f","Charge_0x100f",8000,0,4000));
-   GetOutputList()->Add(new TH1D("EnergySum","EnergySum",5000,0,2500));
+   GetOutputList()->Add(new TH1D("EnergySum","EnergySum",10000,0,5000));
 
    GetOutputList()->Add(new TH1D("Charge_nofilter","Charge_nofilter",8000,0,4000));
    GetOutputList()->Add(new TH1D("Charge_filter","Charge_filter",8000,0,4000));


### PR DESCRIPTION
Fixed multiple bugs in TPeak. I also changes the statement that reads the calibration from a tree to tell you how many channels were read, instead of "This was read if it exists". I would like to make it so we can change the cal written to the fragment/analysis trees at some point, but as of right now this requires copying the entire trees and rewriting them (still better than resorting the midas file I guess).