### PR TITLE
Fixed bugs in offset fix and bufferclean

### DIFF
--- a/util/bufferclean.C
+++ b/util/bufferclean.C
@@ -10,7 +10,7 @@
 #include <iostream>
 #include <fstream>
 
-Int_t chanId_threshold = 50;
+Int_t chanId_threshold = 10;
 
 Bool_t CheckEvent(TMidasEvent *evt){
    //This function does not work if a Midas event contains multiple fragments
@@ -44,8 +44,8 @@ Bool_t CheckEvent(TMidasEvent *evt){
             trigId = value & 0x0fffffff;
       };
    }
-   if(triggermap.find(dignum) == triggermap.end()){
-      triggermap[dignum] = false; //initialize the new digitizer number to false.
+   if(triggermap.find(chanadd) == triggermap.end()){
+      triggermap[chanadd] = false; //initialize the new digitizer number to false.
    }
    //Check to make sure we aren't getting any triggerId's = 0. I think these are corrupt events RD.
    if(trigId == 0){
@@ -53,11 +53,11 @@ Bool_t CheckEvent(TMidasEvent *evt){
    }
 
    //Check against map of trigger Id's to see if we have hit the elusive < threshold mark yet.
-   if(triggermap.find(dignum)->second == true){ 
+   if(triggermap.find(chanadd)->second == true){ 
       return true;
    }
    else if(trigId < chanId_threshold){
-      triggermap.find(dignum)->second = true;
+      triggermap.find(chanadd)->second = true;
       return true;
    }
    else 

--- a/util/offsetfix.C
+++ b/util/offsetfix.C
@@ -677,7 +677,7 @@ int main(int argc, char **argv) {
    infile->Close();
    infile->Open(argv[1]);//This seems like the easiest way to reset the file....
    //It might be worth threading the Read/Write Part of this...its slooooooow.
-  // WriteEvents(infile,outfilemid,correction);
+   WriteEvents(infile,outfilemid,correction);
 
 
    //Have to do deleting on Q if we move to a next step of fixing the MIDAS File

--- a/util/offsetfix.C
+++ b/util/offsetfix.C
@@ -147,7 +147,7 @@ std::map<int,int> TEventTime::digmap;
 
 int QueueEvents(TMidasFile *infile, std::vector<TEventTime*> *eventQ){
    int events_read = 0;
-   const int total_events = 1E6;
+   const int total_events = 1E7;
    TMidasEvent *event  = new TMidasEvent;
    eventQ->reserve(total_events);
 
@@ -254,7 +254,7 @@ void GetRoughTimeDiff(std::vector<TEventTime*> *eventQ, int64_t *correction){
    std::map<int,bool> keep_filling;
    std::map<int,int>::iterator mapit;
    for(mapit = TEventTime::digmap.begin(); mapit!=TEventTime::digmap.end();mapit++){
-      TH1C *roughhist = new TH1C(Form("rough_0x%04x",mapit->first),Form("rough_0x%04x",mapit->first), 6E8,-3E8,3E8); 
+      TH1C *roughhist = new TH1C(Form("rough_0x%04x",mapit->first),Form("rough_0x%04x",mapit->first), 6E7,-3E8,3E8); 
       roughhist->SetTitle(Form("rough_0x%04x against 0x%04x",mapit->first,TEventTime::GetBestDigitizer()));
       roughlist->Add(roughhist);
       keep_filling[mapit->first] = true;
@@ -268,7 +268,7 @@ void GetRoughTimeDiff(std::vector<TEventTime*> *eventQ, int64_t *correction){
    std::vector<TEventTime*>::iterator hit1;
    std::vector<TEventTime*>::iterator hit2;
    int event1count = 0;
-   const int range = 250;
+   const int range = 1000;
    for(hit1 = eventQ->begin(); hit1 != eventQ->end(); hit1++) { //This steps hit1 through the eventQ
       //We want to have the first hit be in the "good digitizer"
       if(event1count%250000 == 0)
@@ -348,7 +348,7 @@ void GetTimeDiff(std::vector<TEventTime*> *eventQ, int64_t *correction){
    std::vector<TEventTime*>::iterator hit1;
    std::vector<TEventTime*>::iterator hit2;
    int event1count = 0;
-   const int range = 250;
+   const int range = 1000;
    for(hit1 = eventQ->begin(); hit1 != eventQ->end(); hit1++) { //This steps hit1 through the eventQ
       //We want to have the first hit be in the "good digitizer"
       if(event1count%75000 == 0)


### PR DESCRIPTION
- These *should* in principle work now. 
- Had to do high time stamp shifts based on the first timestamp seen by a digitizer.
- I did this due to the "I failed so I'm going to write a 0 word" mentality that our DAQ currently has.
- If this method also fails. I'll come up with something trickier, but until then....