### PR TITLE
Added a WriteToAllChannels function

### DIFF
--- a/include/TCFDCal.h
+++ b/include/TCFDCal.h
@@ -1,0 +1,40 @@
+#ifndef TCFDCAL_H__
+#define TCFDCAL_H__
+
+#include "TCal.h"
+
+
+class TCFDCal : public TCal {
+ public: 
+   TCFDCal(){};
+   TCFDCal(const char* name, const char* title) : TCal(name,title){};
+   virtual ~TCFDCal(){}; 
+
+ //pure virtual functions  
+   virtual Bool_t IsGroupable() const {return false;}
+
+ public:
+   virtual void WriteToChannel() const;
+   virtual void ReadFromChannel();
+   virtual std::vector<Double_t> GetParameters() const;
+   virtual Double_t GetParameter(Int_t parameter) const ;
+
+   void AddParameter(Double_t param);
+   void SetParameters(std::vector<Double_t> paramvec);
+   void SetParameter(Int_t idx, Double_t param);
+
+   virtual void WriteToAllChannels(std::string mnominc = "");
+
+   //static TGraphErrors MergeGraphs(TCal *cal,...);
+
+   virtual void Print(Option_t *opt = "") const;
+   virtual void Clear(Option_t *opt = "");
+
+ private:
+   std::vector<Double_t> fparameters;
+
+   ClassDef(TCFDCal,1);
+
+};
+
+#endif

--- a/include/TCFDCal.h
+++ b/include/TCFDCal.h
@@ -23,8 +23,6 @@ class TCFDCal : public TCal {
    void SetParameters(std::vector<Double_t> paramvec);
    void SetParameter(Int_t idx, Double_t param);
 
-   virtual void WriteToAllChannels(std::string mnominc = "");
-
    //static TGraphErrors MergeGraphs(TCal *cal,...);
 
    virtual void Print(Option_t *opt = "") const;

--- a/include/TCal.h
+++ b/include/TCal.h
@@ -44,7 +44,7 @@ class TCal : public TNamed {
    virtual TF1* GetFitFunction() const { return ffitfunc; } 
    virtual void SetFitFunction(const TF1* func){ ffitfunc = (TF1*)func; };
    virtual std::vector<Double_t> GetParameters() const;
-   virtual Double_t GetParameter(Int_t parameter) const ;
+   virtual Double_t GetParameter(Int_t parameter) const;
 
    //static TGraphErrors MergeGraphs(TCal *cal,...);
 
@@ -53,6 +53,8 @@ class TCal : public TNamed {
    Bool_t SetChannel(UInt_t channum);
    virtual void Print(Option_t *opt = "") const;
    virtual void Clear(Option_t *opt = "");
+
+   virtual void WriteToAllChannels(std::string mnemonic = "");
 
    virtual void SetHist(TH1* hist);
    TH1* GetHist() const {return fhist;}

--- a/libraries/TGRSIAnalysis/TCal/TCFDCal.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TCFDCal.cxx
@@ -37,19 +37,6 @@ void TCFDCal::SetParameter(Int_t idx, Double_t param){
    }
 }
 
-void TCFDCal::WriteToAllChannels(std::string mnemonic){
-   std::map<unsigned int,TChannel*>::iterator mapit;
-   std::map<unsigned int,TChannel*> *chanmap = TChannel::GetChannelMap();
-   TChannel* orig_chan = GetChannel();
-   for(mapit = chanmap->begin(); mapit != chanmap->end(); mapit++){
-      if(!mnemonic.size() || !strncmp(mapit->second->GetChannelName(),mnemonic.c_str(),3)){
-         SetChannel(mapit->second);
-         WriteToChannel();
-      }
-   }
-   SetChannel(orig_chan);
-}
-
 void TCFDCal::ReadFromChannel() {
    if(!GetChannel()){
       Error("ReadFromChannel","No Channel Set");

--- a/libraries/TGRSIAnalysis/TCal/TCFDCal.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TCFDCal.cxx
@@ -1,0 +1,87 @@
+#include "TCFDCal.h"
+
+ClassImp(TCFDCal)
+
+void TCFDCal::Clear(Option_t *opt) {
+   fparameters.clear();
+   TCal::Clear(opt);
+}
+
+void TCFDCal::WriteToChannel() const {
+   if(!GetChannel()){
+      Error("WriteToChannel","No Channel Set");
+      return;
+   }
+   GetChannel()->DestroyCFDCal();
+   printf("\nWriting to channel %d\n",GetChannel()->GetNumber());
+   for(int i=0;i<fparameters.size();i++){
+      printf("p%i = %lf \t",i,fparameters.at(i));
+      GetChannel()->AddCFDCoefficient(fparameters.at(i));
+   }
+}
+
+void TCFDCal::AddParameter(Double_t param){
+   fparameters.push_back(param);
+}
+
+void TCFDCal::SetParameters(std::vector<Double_t> paramvec){
+   fparameters = paramvec;
+}
+
+void TCFDCal::SetParameter(Int_t idx, Double_t param){
+   try {
+	   fparameters.at(idx) = param;
+   } 
+   catch(const std::out_of_range& oor) {
+      Error("SetParameter","Parameter %d does not exist yet",idx);
+   }
+}
+
+void TCFDCal::WriteToAllChannels(std::string mnemonic){
+   std::map<unsigned int,TChannel*>::iterator mapit;
+   std::map<unsigned int,TChannel*> *chanmap = TChannel::GetChannelMap();
+   TChannel* orig_chan = GetChannel();
+   for(mapit = chanmap->begin(); mapit != chanmap->end(); mapit++){
+      if(!mnemonic.size() || !strncmp(mapit->second->GetChannelName(),mnemonic.c_str(),3)){
+         SetChannel(mapit->second);
+         WriteToChannel();
+      }
+   }
+   SetChannel(orig_chan);
+}
+
+void TCFDCal::ReadFromChannel() {
+   if(!GetChannel()){
+      Error("ReadFromChannel","No Channel Set");
+      return;
+   }
+   fparameters = GetChannel()->GetCFDCoeff();
+}
+
+void TCFDCal::Print(Option_t *opt) const{
+   if(GetChannel())
+      printf("Channel Number: %u\n",GetChannel()->GetNumber());
+   else
+      printf("Channel Number: NOT SET\n");
+
+   for(int i=0;i<fparameters.size();i++){
+      printf("p%i = %lf \t",i,fparameters.at(i));
+   }
+}
+
+std::vector<Double_t> TCFDCal::GetParameters() const{
+  
+   if(!fparameters.size())
+      Error("GetParameters","No Parameters Set");
+
+   return fparameters;
+}
+
+Double_t TCFDCal::GetParameter(Int_t parameter) const{
+   if(parameter < fparameters.size() )
+      return fparameters.at(parameter);
+   else{
+      Error("Get Parameter","Parameter Does not exist");
+      return 0;
+   }
+}

--- a/libraries/TGRSIAnalysis/TCal/TCal.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TCal.cxx
@@ -83,6 +83,10 @@ Bool_t TCal::SetChannel(const TChannel* chan){
    return true;
 }
 
+void TCal::WriteToAllChannels(std::string mnemonic){
+   Error("WriteToAllChannels","Not Defined for %c",ClassName());
+}
+
 std::vector<Double_t> TCal::GetParameters() const{
    std::vector<Double_t> paramlist;
    if(!GetFitFunction()){

--- a/libraries/TGRSIAnalysis/TCal/TCal.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TCal.cxx
@@ -76,6 +76,7 @@ void TCal::Copy(TObject &obj) const{
 Bool_t TCal::SetChannel(const TChannel* chan){
    if(!chan){
       Error("SetChannel","TChannel does not exist");
+      printf("%p\n",chan);
       return false;
    }
    //Set our TRef to point at the TChannel
@@ -84,7 +85,17 @@ Bool_t TCal::SetChannel(const TChannel* chan){
 }
 
 void TCal::WriteToAllChannels(std::string mnemonic){
-   Error("WriteToAllChannels","Not Defined for %c",ClassName());
+   std::map<unsigned int,TChannel*>::iterator mapit;
+   std::map<unsigned int,TChannel*> *chanmap = TChannel::GetChannelMap();
+   TChannel* orig_chan = GetChannel();
+   for(mapit = chanmap->begin(); mapit != chanmap->end(); mapit++){
+      if(!mnemonic.size() || !strncmp(mapit->second->GetChannelName(),mnemonic.c_str(),3)){
+         SetChannel(mapit->second);
+         WriteToChannel();
+      }
+   }
+   if(orig_chan)
+      SetChannel(orig_chan);
 }
 
 std::vector<Double_t> TCal::GetParameters() const{

--- a/libraries/TGRSIAnalysis/TCal/makefile
+++ b/libraries/TGRSIAnalysis/TCal/makefile
@@ -1,5 +1,5 @@
 
-OBJECTS = TCal.o TCalDict.o TEfficiencyCal.o TEfficiencyCalDict.o TEnergyCal.o TEnergyCalDict.o TGainMatch.o TGainMatchDict.o TCalManager.o TCalManagerDict.o
+OBJECTS = TCal.o TCalDict.o TEfficiencyCal.o TEfficiencyCalDict.o TEnergyCal.o TEnergyCalDict.o TGainMatch.o TGainMatchDict.o TCFDCal.o TCFDCalDict.o TCalManager.o TCalManagerDict.o
 
 CFLAGS += -fPIC
 


### PR DESCRIPTION
- This was meant for CFD, but now all TCal's can be written to all channels.
- for any given TCal that has a WriteToChannel function (all of them), one can call WriteToAllChannels(mnemonic), where mnemonic is a string that chooses which channels to write to. For example "GRG" writes to all channels, while "GRG01" writes to the first clover.
1. To set CFD parameters, set all of the TChannels (TChannel::ReadCalFile)
2. TCFDCal * cal = new TCFDCal
3. cal->AddParameter(parameter1)
4. cal->AddParameter(parameter2) etc.
5. WriteToAllChannels(mnemonic)
6. TChannel::WriteCalFile
