### PR TITLE
Modified offsetfix to use TSpectrum for final peak fit

### DIFF
--- a/util/makefile
+++ b/util/makefile
@@ -15,7 +15,7 @@ CAT=cat
 
 .PHONY: all clean gone end
 
-UTILFLAGS =  -L$(GRSISYS)/libraries  -lAnalysisTreeBuilder -lGriffin -lSceptar -lDescant -lPaces -lGRSIDetector -lTGRSIFit -lTigress -lSharc -lCSM -lTriFoil -lTGRSIint -lGRSILoop -lMidasFormat -lGRSIRootIO -lDataParser -lGRSIFormat -lMidasFormat -lXMLParser -lXMLIO -lProof -lGuiHtml `root-config --cflags --libs` -lTreePlayer -lGROOT -lX11 -lXpm
+UTILFLAGS =  -L$(GRSISYS)/libraries  -lAnalysisTreeBuilder -lGriffin -lSceptar -lDescant -lPaces -lGRSIDetector -lTGRSIFit -lTigress -lSharc -lCSM -lTriFoil -lTGRSIint -lGRSILoop -lMidasFormat -lGRSIRootIO -lDataParser -lGRSIFormat -lMidasFormat -lXMLParser -lXMLIO -lProof -lGuiHtml `root-config --cflags --libs` -lTreePlayer -lGROOT -lX11 -lXpm -lSpectrum
 
 
 UTIL_STRING = "Finished compiling utilities"

--- a/util/offsetfix.C
+++ b/util/offsetfix.C
@@ -6,6 +6,7 @@
 #include"GFile.h"
 #include"TFragment.h"
 #include"TTree.h"
+#include"TSpectrum.h"
 #include"TChannel.h"
 #include"TH2D.h"
 #include "TTreeIndex.h"
@@ -465,14 +466,11 @@ void GetTimeDiff(std::vector<TEventTime*> *eventQ, int64_t *correction){
       if(mapit->first == TEventTime::GetBestDigitizer())
          continue;
       fillhist = (TH1D*)(list->At(mapit->second));
-      std::cout << static_cast<int64_t>(fillhist->GetBinCenter(fillhist->GetMaximumBin())) << std::endl;
-      correction[mapit->second] +=  static_cast<int64_t>(fillhist->GetBinCenter(fillhist->GetMaximumBin()));
-      TPolyMarker *pm = new TPolyMarker;
-      pm->SetNextPoint(fillhist->GetBinCenter(fillhist->GetMaximumBin()),fillhist->GetBinContent(fillhist->GetMaximumBin())+10);
-      pm->SetMarkerStyle(23);
-      pm->SetMarkerColor(kRed);
-      pm->SetMarkerSize(1.3);
-      fillhist->GetListOfFunctions()->Add(pm);
+      TSpectrum* spec = new TSpectrum();
+      spec->Search(fillhist);
+      double peak = spec->GetPositionX()[0];
+      std::cout << static_cast<int64_t>(peak) << std::endl;
+      correction[mapit->second] +=  static_cast<int64_t>(peak);
  //     fillhist->Draw();
 
    }


### PR DESCRIPTION
It's helpful to be a bit more robust that doing a max bin find when the peak will be a bit broader.