### PR TITLE
Fixed TChannel reading into TFragmentSelector in current version

### DIFF
--- a/include/TFragmentSelector.h
+++ b/include/TFragmentSelector.h
@@ -127,8 +127,16 @@ void TFragmentSelector::Init(TTree *tree)
    fChain = tree;
 
    fChain->SetBranchAddress("TFragment",&fragment);
+   //Start by reading calirbations from tree
+   TChannel::ReadCalFromTree(tree);
+      
+   //Then load the calibration information from the first cal file on the command line, and over writes other channels with any cal files that follow
+  // if(!TGRSIOptions::GetInputCal().empty())
+  //    for(int x = 0;x<TGRSIOptions::GetInputCal().size();x++) 
+  //       TChannel::ReadCalFile(TGRSIOptions::GetInputCal().at(x).c_str());
+      
 
-
+/*
   if(TChannel::GetNumberOfChannels()==0) {
      TList *chanlist = fChain->GetUserInfo();
      TIter iter(chanlist);
@@ -142,7 +150,7 @@ void TFragmentSelector::Init(TTree *tree)
         //TChannel::CopyChannel(newchan,chan);
      }
    }
-
+*/
 
 
 /*


### PR DESCRIPTION
- This is for people who use the -s command
- Only reads TChannels out of the tree, I believe it will completely ignore Cal files. We don't use this enough to put the time into fixing the problem any more than this.