### PR TITLE
Changed WriteToRoot to only reopen read only files.

### DIFF
--- a/libraries/TGRSIFormat/TChannel.cxx
+++ b/libraries/TGRSIFormat/TChannel.cxx
@@ -921,9 +921,11 @@ int TChannel::WriteToRoot(TFile *fileptr) {
       
   fileptr->cd();
   std::string oldoption = std::string(fileptr->GetOption());
-  fileptr->ReOpen("UPDATE");
-  if(!gDirectory)
-     printf("No file opened to wrtie to.\n");
+  if(oldoption == "READ") {
+    fileptr->ReOpen("UPDATE");
+  }
+	if(!gDirectory)
+     printf("No file opened to write to.\n");
   TIter iter(gDirectory->GetListOfKeys());
 
   //printf("1 Number of Channels: %i\n",GetNumberOfChannels());
@@ -983,9 +985,11 @@ int TChannel::WriteToRoot(TFile *fileptr) {
   //TChannel::DeleteAllChannels();
   //gDirectory->GetFile()->Get("c->GetName()");
   printf("  %i TChannels saved to %s.\n",GetNumberOfChannels(),gDirectory->GetFile()->GetName());
-  printf("  Returning %s to \"%s\" mode.\n",gDirectory->GetFile()->GetName(),oldoption.c_str());
-  fileptr->ReOpen(oldoption.c_str());
-  savdir->cd();//Go back to original gDirectory
+  if(oldoption == "READ") {
+    printf("  Returning %s to \"%s\" mode.\n",gDirectory->GetFile()->GetName(),oldoption.c_str());
+    fileptr->ReOpen("READ");
+  }
+	savdir->cd();//Go back to original gDirectory
   return GetNumberOfChannels();
 }
 


### PR DESCRIPTION
Previously WriteToRoot reopened all files as UPDATE, then reopened again using the original open type.  This caused a warning with CREATE, as you can't reopen with CREATE.  WriteToRoot now reopens as UPDATE iff it was opened READ only, then returns the file to READ only after updating the calibration.