### PR TITLE
Accessing TPeak area from histogram

### DIFF
--- a/include/TPeak.h
+++ b/include/TPeak.h
@@ -66,12 +66,12 @@ class TPeak : public TGRSIFit {
    const char*  PrintString(Option_t *opt = "") const;
    virtual void Clear();
 
- private:  
+ private: 
    //Centroid will eventually be read from parameters
-   Double_t farea; //->
-   Double_t fd_area; //->
-   Double_t fchi2; //->
-   Double_t fNdf; //->
+   Double_t farea; 
+   Double_t fd_area; 
+   Double_t fchi2; 
+   Double_t fNdf; 
 
   ClassDef(TPeak,2);
 

--- a/libraries/GROOT/GCanvas.cxx
+++ b/libraries/GROOT/GCanvas.cxx
@@ -458,8 +458,8 @@ TF1 *GCanvas::GetLastFit() {
   if(!hist)
      return 0;
   if(hist->GetListOfFunctions()->GetSize()>0) 
-     return ((TF1*)hist->GetListOfFunctions()->Last()); 
-  return 0; 
+     return (TF1*)(hist->GetListOfFunctions()->Last()); 
+  return 0;
 }
 
 
@@ -672,9 +672,9 @@ bool GCanvas::PeakFit(GMarker *m1,GMarker *m2) {
     }
   }
   
-  TPeak *mypeak = (TPeak*)(hist->GetFunction("peak"));
-  if(mypeak)
-     mypeak->Delete();
+ // TPeak *mypeak = (TPeak*)(hist->GetFunction("peak"));
+ // if(mypeak)
+  //   mypeak->Delete();
   int binx[2];
   double x[2];
   double y[2];
@@ -688,7 +688,7 @@ bool GCanvas::PeakFit(GMarker *m1,GMarker *m2) {
     y[1]=hist->GetBinContent(m1->x); y[0]=hist->GetBinContent(m2->x); 
   }
   //printf("x[0] = %.02f   x[1] = %.02f\n",x[0],x[1]);
-  mypeak = new TPeak((x[0]+x[1])/2.0,x[0],x[1]);
+  TPeak* mypeak = new TPeak((x[0]+x[1])/2.0,x[0],x[1]);
 //  TF1 *gfit = new TF1("gaus","gaus",x[0],x[1]);
 //  hist->Fit(gfit,"QR+");
 
@@ -742,9 +742,6 @@ bool GCanvas::PeakFitQ(GMarker *m1,GMarker *m2) {
     }
   }
   
-  TPeak *mypeak = (TPeak*)(hist->GetFunction("peak"));
-  if(mypeak)
-     mypeak->Delete();
   int binx[2];
   double x[2];
   double y[2];
@@ -758,7 +755,11 @@ bool GCanvas::PeakFitQ(GMarker *m1,GMarker *m2) {
     y[1]=hist->GetBinContent(m1->x); y[0]=hist->GetBinContent(m2->x); 
   }
   //printf("x[0] = %.02f   x[1] = %.02f\n",x[0],x[1]);
-  mypeak = new TPeak((x[0]+x[1])/2.0,x[0],x[1]);
+  TPeak * mypeak = new TPeak((x[0]+x[1])/2.0,x[0],x[1]);
+/*  if(hist->FindObject(mypeak->GetName())){
+     //delete mypeak;
+     mypeak = (TPeak*)(hist->FindObject(mypeak->GetName()));
+  }*/
 //  TF1 *gfit = new TF1("gaus","gaus",x[0],x[1]);
 //  hist->Fit(gfit,"QR+");
 
@@ -767,14 +768,14 @@ bool GCanvas::PeakFitQ(GMarker *m1,GMarker *m2) {
 //  gfit->Delete();
   //hist->GetFunction("gaus")->Delete();
 
-  mypeak->Fit(hist,"QR+");
-  TF1 *peakfit = (TF1*)hist->GetListOfFunctions()->Last();
+  mypeak->Fit(hist,"Q+");
+  TPeak *peakfit = (TPeak*)(hist->GetListOfFunctions()->Last());
   //hist->GetListOfFunctions()->Print();
   if(!peakfit) {
     printf("peakfit not found??\n");
     return false;
   }
-  ((TPeak*)peakfit)->Print();
+  mypeak->Print();
   
      
 /* 

--- a/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFit.cxx
@@ -13,7 +13,6 @@ TGRSIFit::TGRSIFit(const TGRSIFit &copy) : TF1(copy){
 void TGRSIFit::Copy(TObject &obj) const{
    ((TGRSIFit&)obj).init_flag   = init_flag;
    ((TGRSIFit&)obj).goodfit_flag= goodfit_flag;
-   
    TF1::Copy(obj);
 
 }

--- a/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
@@ -225,9 +225,9 @@ Bool_t TPeak::Fit(TH1* fithist,Option_t *opt){
 
    if(Print) printf("Integral: %lf +/- %lf\n",farea,fd_area);
    //To DO: put a flag in signalling that the errors are not to be trusted if we have a bad cov matrix
-   Copy(*fithist->GetFunction(GetName()));
+   Copy(*fithist->GetListOfFunctions()->Last());
    if(optstr.Contains("+"))
-      Copy(*fithist->GetListOfFunctions()->Last());
+      Copy(*fithist->GetListOfFunctions()->Before(fithist->GetListOfFunctions()->Last()));
    delete tmppeak;
    
 }

--- a/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
@@ -69,12 +69,12 @@ TPeak::TPeak(const TPeak &copy) : TGRSIFit(copy){
 }
 
 void TPeak::Copy(TObject &obj) const {
+   TGRSIFit::Copy(obj);
    ((TPeak&)obj).farea = farea;
    ((TPeak&)obj).fd_area = fd_area;
 
    ((TPeak&)obj).fchi2 = fchi2;
    ((TPeak&)obj).fNdf  = fNdf;
-   TGRSIFit::Copy(obj);
 }
 
 
@@ -145,6 +145,7 @@ Bool_t TPeak::InitParams(TH1 *fithist){
 }
 
 Bool_t TPeak::Fit(TH1* fithist,Option_t *opt){
+   TString optstr = opt;
    if(!fithist && fHistogram){
       printf("No hist passed, trying something...");
       fithist = fHistogram;
@@ -224,7 +225,10 @@ Bool_t TPeak::Fit(TH1* fithist,Option_t *opt){
 
    if(Print) printf("Integral: %lf +/- %lf\n",farea,fd_area);
    //To DO: put a flag in signalling that the errors are not to be trusted if we have a bad cov matrix
-   //delete tmppeak;
+   Copy(*fithist->GetFunction(GetName()));
+   if(optstr.Contains("+"))
+      Copy(*fithist->GetListOfFunctions()->Last());
+   delete tmppeak;
    
 }
 


### PR DESCRIPTION
Being able to access the TPeak area from the histogram has been solved. Now the TPeak is fit, and the last function fit is copied to be this peak. If the option "+" is used when fitting the TPeak, the last two functions are copied, as the + option appends the function to the histogram, but then still writes the current function leaving two copies attached until the last one is overwritten by a new fit. That's just the way ROOT does it.